### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/statistics.yml
+++ b/.github/workflows/statistics.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 12 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   generate-stats:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/BoBoBaSs84/security/code-scanning/2](https://github.com/BoBoBaSs84/BoBoBaSs84/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so the default `GITHUB_TOKEN` is least-privileged.  
Because this job commits and pushes to the repository, it needs `contents: write` (not just read).  
The best fix is to add the block at the workflow root (below `on:`), so it applies to all jobs unless overridden.

**File to change:** `.github/workflows/statistics.yml`  
**Change:** insert:

```yml
permissions:
  contents: write
```

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
